### PR TITLE
Add ARM64 support for aclk_clock()

### DIFF
--- a/misc.h
+++ b/misc.h
@@ -107,6 +107,14 @@ static __inline__ unsigned long long aclk_clock(void)
 
 	return(result);
 }
+#elif defined(__aarch64__)
+#define ACLK_HW_CLOCK
+static __inline__ unsigned long long aclk_clock(void)
+{
+	unsigned long long int val;
+	__asm__ __volatile__("mrs %0, cntvct_el0" : "=r"(val));
+	return val;
+}
 
 #else
 static inline unsigned long long aclk_clock(void)


### PR DESCRIPTION
This commit add ARM64 support for aclk_clock() which is using ARMv8
Counter-timer inside.

Signed-off-by: Guoju Fang <fangguoju@gmail.com>