### PR TITLE
add hugepage support in masim

### DIFF
--- a/configs/2mb.cfg
+++ b/configs/2mb.cfg
@@ -1,0 +1,12 @@
+#regions
+# name, length
+a, 2097152
+
+# phase 1
+# name of phase
+huge phase 1
+# time in ms
+5000
+# access patterns
+# name of region, randomness, stride, probability
+a, 1, 64, 80


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Currently masim does not have support for using hugepages. Hugepage support is needed to implement hugepage tests in damon-tests/corr as discussed here : https://lore.kernel.org/damon/20220816205030.96988-1-sj@kernel.org/T/
This PR adds support for hugepages. Code is taken from tools/testing/selftests/vm/map_hugetlb.c.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
