### PR TITLE
fix random rndints for 64 bits address space

### DIFF
--- a/configs/64.cfg
+++ b/configs/64.cfg
@@ -1,0 +1,23 @@
+#regions
+# name, length
+a, 2147483648
+b, 64
+c, 128
+
+# phase 1
+# name of phase
+example phase 1
+# time in ms
+1000
+# access patterns
+# name of region, randomness, stride, probability
+a, 1, 64, 80
+
+# phase 2
+example phase 2
+# time in ms
+1000
+# access patterns
+# name of region, randomness, stride, probability
+c, 1, 64, 50
+b, 0, 4096, 50

--- a/masim.c
+++ b/masim.c
@@ -87,7 +87,11 @@ struct access_config {
 
 #define RAND_BATCH	1000
 #define RAND_ARR_SZ	1000
-int rndints[RAND_BATCH][RAND_ARR_SZ];
+size_t rndints[RAND_BATCH][RAND_ARR_SZ];
+
+inline static size_t rand64() {
+	return ((size_t)rand() << 32) | rand();
+}
 
 static void init_rndints(void)
 {
@@ -95,14 +99,14 @@ static void init_rndints(void)
 
 	for (i = 0; i < RAND_BATCH; i++)
 		for (j = 0; j < RAND_ARR_SZ; j++)
-			rndints[i][j] = rand();
+			rndints[i][j] = rand64();
 	rndints[0][0] = 1;
 }
 
 /*
  * Returns a random integer
  */
-static int rndint(void)
+static size_t rndint(void)
 {
 	static int rndofs;
 	static int rndarr;


### PR DESCRIPTION
int rand() could only generate random number in 0-2^31-1, but the region size is size_t(64B), not all addresses in the range could get accessed.
